### PR TITLE
Support Rails exception discarding when deserializing

### DIFF
--- a/lib/activejob/locking/base.rb
+++ b/lib/activejob/locking/base.rb
@@ -31,7 +31,11 @@ module ActiveJob
         def adapter
           @adapter ||= begin
             # Make sure arguments are deserialized so calling lock key is safe
-            deserialize_arguments_if_needed
+            begin
+              deserialize_arguments_if_needed
+            rescue => exception
+              rescue_with_handler(exception) || raise
+            end
 
             # Merge local and global options
             merged_options = ActiveJob::Locking.options.dup.merge(self.class.lock_options)


### PR DESCRIPTION
Due to the structure of `activejob-locking` we're currently not able to discard jobs that raise `ActiveJob::DeserializationError` using the ActiveJob `discard_on` / `retry_on` options.

This PR adds support for ActiveJob rescue flow when deserializing the arguments.

I'm BTW not able to run the test suite without build failures even in `master`.