### PR TITLE
Fix `unlock` for Redlock adapter

### DIFF
--- a/lib/activejob/locking/adapters/redlock.rb
+++ b/lib/activejob/locking/adapters/redlock.rb
@@ -17,7 +17,7 @@ module ActiveJob
         end
 
         def unlock
-          self.lock_manager.unlock(self.lock_token)
+          self.lock_manager.unlock(self.lock_token.symbolize_keys)
           self.lock_token = nil
         end
       end


### PR DESCRIPTION
When lock is deserialized, it is hash containing strings as keys.
Though, Redlock expects lock to have Symbols as keys.
Hence, the job is completed without releasing a lock.

This might be valid for other adapters. (I have not checked it)
If so, the problem must be fixed on `desecialize` step.

Did not find how to set up test environment, so don't have specs,
unfortunately.