### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class SerializedJob < ActiveJob::Base
   include ActiveJob::Locking::Serialized
 
   # Make sure the lock_key is always the same
-  def lock_key
+  def lock_key(object)
     self.class.name
   end
 


### PR DESCRIPTION
For Serialized Jobs: lock_key takes in 1 argument (just like in Unique Jobs). Otherwise you'll run into an error.